### PR TITLE
🔒 [security fix] Fix Log Injection in Error Messages

### DIFF
--- a/crockford32.go
+++ b/crockford32.go
@@ -103,7 +103,7 @@ type ErrInvalidRunes struct {
 // Error returns a string representation of the ErrInvalidRunes error.
 // It formats the error message to include the input string and the invalid runes found during decoding.
 func (e ErrInvalidRunes) Error() string {
-	return fmt.Sprintf(`crockford32.Parse("%s"): contains invalid runes %s`, e.input, e.runes)
+	return fmt.Sprintf("crockford32.Parse(%.32q): contains invalid runes %.32q", e.input, e.runes)
 }
 
 // ErrEmptyString is an error type that is returned when an empty string is passed to the Crockford32 encoding function.
@@ -121,5 +121,5 @@ type ErrInputTooLong struct {
 
 // Error returns the error message for an input string that is too long.
 func (e ErrInputTooLong) Error() string {
-	return fmt.Sprintf(`crockford32.Parse("%s"): input too long`, e.input)
+	return fmt.Sprintf("crockford32.Parse(%.32q): input too long", e.input)
 }

--- a/crockford32_test.go
+++ b/crockford32_test.go
@@ -95,7 +95,7 @@ func ExampleParse_invalid() {
 	if err != nil {
 		fmt.Println(err)
 	}
-	// Output: crockford32.Parse("1!2@3#"): contains invalid runes !@#
+	// Output: crockford32.Parse("1!2@3#"): contains invalid runes "!@#"
 }
 
 // ExampleErrEmptyString demonstrates the error message for an empty input string.


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is Log Injection / Reflected Output in error messages (`ErrInvalidRunes.Error()` and `ErrInputTooLong.Error()`).

⚠️ **Risk:** An attacker could provide malicious input (e.g., containing control characters or newlines) that would be reflected in the application's logs, potentially leading to log forging or Denial of Service (DoS) through extremely long log entries.

🛡️ **Solution:** Switched from `%s` with manual quoting to `%.32q` for all reflected user input in error messages. This ensures that the input is safely quoted, all control characters are escaped (e.g., `\n` becomes `\\n`), and the output is truncated to 32 characters to prevent log bloating.

---
*PR created automatically by Jules for task [7596586566619213460](https://jules.google.com/task/7596586566619213460) started by @mrkhn*