### PR TITLE
🔒 Fix Denial of Service and Log Forging in error messages

### DIFF
--- a/crockford32.go
+++ b/crockford32.go
@@ -103,7 +103,17 @@ type ErrInvalidRunes struct {
 // Error returns a string representation of the ErrInvalidRunes error.
 // It formats the error message to include the input string and the invalid runes found during decoding.
 func (e ErrInvalidRunes) Error() string {
-	return fmt.Sprintf(`crockford32.Parse("%s"): contains invalid runes %s`, e.input, e.runes)
+	input := e.input
+	if len(input) > 32 {
+		input = input[:32] + "..."
+	}
+
+	runes := e.runes
+	if len(runes) > 32 {
+		runes = runes[:32] + "..."
+	}
+
+	return fmt.Sprintf(`crockford32.Parse(%q): contains invalid runes %q`, input, runes)
 }
 
 // ErrEmptyString is an error type that is returned when an empty string is passed to the Crockford32 encoding function.
@@ -121,5 +131,10 @@ type ErrInputTooLong struct {
 
 // Error returns the error message for an input string that is too long.
 func (e ErrInputTooLong) Error() string {
-	return fmt.Sprintf(`crockford32.Parse("%s"): input too long`, e.input)
+	input := e.input
+	if len(input) > 32 {
+		input = input[:32] + "..."
+	}
+
+	return fmt.Sprintf(`crockford32.Parse(%q): input too long`, input)
 }

--- a/crockford32_test.go
+++ b/crockford32_test.go
@@ -4,7 +4,6 @@
 package crockford32
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -40,7 +39,7 @@ func TestParse(t *testing.T) {
 		t.Run(fmt.Sprint(test.input), func(t *testing.T) {
 			output, err := Parse(test.input)
 			actual := results{output, err}
-			if actual.output != test.expected.output || !errors.Is(actual.err, test.expected.err) {
+			if actual.output != test.expected.output || (actual.err != nil && test.expected.err != nil && actual.err.Error() != test.expected.err.Error()) || (actual.err == nil && test.expected.err != nil) || (actual.err != nil && test.expected.err == nil) {
 				t.Errorf(`Parse(%v) = %d, "%v"; expected %d, "%v"`, test.input, actual.output, actual.err, test.expected.output, test.expected.err)
 			}
 		})
@@ -95,7 +94,7 @@ func ExampleParse_invalid() {
 	if err != nil {
 		fmt.Println(err)
 	}
-	// Output: crockford32.Parse("1!2@3#"): contains invalid runes !@#
+	// Output: crockford32.Parse("1!2@3#"): contains invalid runes "!@#"
 }
 
 // ExampleErrEmptyString demonstrates the error message for an empty input string.

--- a/repro_test.go
+++ b/repro_test.go
@@ -1,0 +1,42 @@
+package crockford32
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestSecurityVulnerabilityReproduction(t *testing.T) {
+	t.Run("ErrInputTooLong_TruncationAndQuoting", func(t *testing.T) {
+		longInput := strings.Repeat("A", 1024)
+		_, err := Parse(longInput)
+		if err == nil {
+			t.Fatal("expected error for long input, got nil")
+		}
+
+		errStr := err.Error()
+		// New behavior: should be quoted and truncated.
+		// "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA..." (32 As)
+		expectedInput := strings.Repeat("A", 32) + "..."
+		expectedInfix := fmt.Sprintf(`Parse(%q):`, expectedInput)
+		if !strings.Contains(errStr, expectedInfix) {
+			t.Errorf("expected error message to contain truncated and quoted input, but it didn't. Got: %s", errStr)
+		}
+	})
+
+	t.Run("ErrInvalidRunes_SafeQuoting", func(t *testing.T) {
+		maliciousInput := "invalid\ninput\""
+		_, err := Parse(maliciousInput)
+		if err == nil {
+			t.Fatal("expected error for invalid input, got nil")
+		}
+
+		errStr := err.Error()
+		// New behavior: should be quoted. %q will escape \n and ".
+		expectedInput := maliciousInput
+		expectedInfix := fmt.Sprintf(`Parse(%q):`, expectedInput)
+		if !strings.Contains(errStr, expectedInfix) {
+			t.Errorf("expected error message to contain safely quoted input, but it didn't. Got: %s", errStr)
+		}
+	})
+}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the direct formatting of untrusted, potentially unbounded input into error messages using `%s` without truncation.
⚠️ **Risk:** A large input (MBs) could cause a Denial of Service by exhausting memory or disk space when logged. Malicious characters like newlines could also be used for log forging.
🛡️ **Solution:** Truncated error message inputs to 32 characters and used the `%q` format specifier in Go to ensure safe quoting and escaping of all untrusted input. Updated tests to reflect these security improvements.

---
*PR created automatically by Jules for task [9057641459201280145](https://jules.google.com/task/9057641459201280145) started by @mrkhn*