### PR TITLE
🧪 [TestFormat] Add edge case test for MaxUint64

### DIFF
--- a/crockford32_test.go
+++ b/crockford32_test.go
@@ -124,6 +124,7 @@ func TestFormat(t *testing.T) {
 		{input: 10, expected: "A"},
 		{input: 32, expected: "10"},
 		{input: math.MaxInt64, expected: "7ZZZZZZZZZZZZ"},
+		{input: math.MaxUint64, expected: "FZZZZZZZZZZZZ"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing edge case test for `math.MaxUint64` in the `Format()` function.
📊 **Coverage:** The scenario where the input is the maximum possible `uint64` value (`18446744073709551615`) is now tested.
✨ **Result:** The test coverage is improved, providing more confidence that `Format()` correctly handles this upper bound limit.

---
*PR created automatically by Jules for task [6165431441683268164](https://jules.google.com/task/6165431441683268164) started by @mrkhn*